### PR TITLE
refactor: standardize Discord types on discord-api-types/v10

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,5 +1,4 @@
 import 'vitest';
-import './tests/customMatchers/customMatchers.d.ts';
 
 declare global {
   namespace NodeJS {

--- a/src/api.ts
+++ b/src/api.ts
@@ -6,8 +6,8 @@ import { v4 } from 'uuid';
 import {
   InteractionResponseType,
   InteractionType,
-  verifyKeyMiddleware,
-} from 'discord-interactions';
+} from 'discord-api-types/v10';
+import { verifyKeyMiddleware } from 'discord-interactions';
 
 import { logger } from './logger.js';
 import { slashcommands } from './commands/slash/index.js';
@@ -62,7 +62,7 @@ app.get('/health', (_req, res) => {
 
 /**
  * Interactions endpoint URL where Discord will send HTTP requests
- * Parse request body and verifies incoming requests using discord-interactions package
+ * Parse request body and verifies incoming Discord interaction signatures
  */
 app.post(
   '/interactions',
@@ -81,15 +81,15 @@ app.post(
     /**
      * Handle verification requests
      */
-    if (type === InteractionType.PING) {
-      return res.send({ type: InteractionResponseType.PONG });
+    if (type === InteractionType.Ping) {
+      return res.send({ type: InteractionResponseType.Pong });
     }
 
     /**
      * Handle slash command requests
      * See https://discord.com/developers/docs/interactions/application-commands#slash-commands
      */
-    if (type === InteractionType.APPLICATION_COMMAND) {
+    if (type === InteractionType.ApplicationCommand) {
       const { name } = data;
       if (slashcommands.hasOwnProperty(name) && slashcommands[name]) {
         logger.debug(`interaction handler`, { reqId, name });
@@ -101,10 +101,9 @@ app.post(
     }
 
     if (
-      [
-        InteractionType.MESSAGE_COMPONENT,
-        InteractionType.MODAL_SUBMIT,
-      ].includes(type)
+      [InteractionType.MessageComponent, InteractionType.ModalSubmit].includes(
+        type,
+      )
     ) {
       const { custom_id } = data;
       if (custom_id.startsWith('{"t":"cta","d":{"a":"')) {

--- a/src/commands/assert/assertInteractionUserIsModerator.ts
+++ b/src/commands/assert/assertInteractionUserIsModerator.ts
@@ -1,4 +1,5 @@
-import { type APIBaseInteraction, type InteractionType } from 'discord.js';
+import type { APIBaseInteraction } from 'discord-api-types/v10';
+import type { InteractionType } from 'discord-api-types/v10';
 import { t } from '../../i18n/index.js';
 
 type InteractionTypeOpts =

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,6 +1,6 @@
+import type { APIBaseInteraction } from 'discord-api-types/v10';
+import { InteractionType } from 'discord-api-types/v10';
 import {
-  APIBaseInteraction,
-  InteractionType,
   SlashCommandBuilder,
   SlashCommandOptionsOnlyBuilder,
   SlashCommandSubcommandsOnlyBuilder,

--- a/src/commands/commonMessages.ts
+++ b/src/commands/commonMessages.ts
@@ -1,14 +1,14 @@
 import {
-  InteractionResponseFlags,
+  ComponentType,
   InteractionResponseType,
-  MessageComponentTypes,
-} from 'discord-interactions';
+  MessageFlags,
+} from 'discord-api-types/v10';
 import { t } from '../i18n/index.js';
 
 export const errorPayload = (content: string) => ({
-  type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+  type: InteractionResponseType.ChannelMessageWithSource,
   data: {
-    flags: InteractionResponseFlags.EPHEMERAL,
+    flags: MessageFlags.Ephemeral,
     content,
   },
 });
@@ -22,11 +22,11 @@ export const doNotUpdatePublishedPoll = () =>
 
 export const foundItComponnents = () => [
   {
-    type: MessageComponentTypes.TEXT_DISPLAY,
+    type: ComponentType.TextDisplay,
     content: t('common.foundIt'),
   },
   {
-    type: MessageComponentTypes.SEPARATOR,
+    type: ComponentType.Separator,
     divider: true,
     spacing: 1,
   },
@@ -34,7 +34,7 @@ export const foundItComponnents = () => [
 
 export const okComponnents = () => [
   {
-    type: MessageComponentTypes.TEXT_DISPLAY,
+    type: ComponentType.TextDisplay,
     content: t('common.ok'),
   },
 ];

--- a/src/commands/cta/poll/pollCreate.ts
+++ b/src/commands/cta/poll/pollCreate.ts
@@ -2,6 +2,7 @@ import {
   ButtonStyle,
   ComponentType,
   InteractionResponseType,
+  MessageFlags,
 } from 'discord-api-types/v10';
 import {
   ComponentSelect,
@@ -11,7 +12,6 @@ import {
   getInputComponnentsByPrefix,
   ModalHandlerDelcaration,
 } from '../../modals.js';
-import { InteractionResponseFlags } from 'discord-interactions';
 import { DiscordGuild } from '../../../db/entities/DiscordGuild.entity.js';
 import { Poll } from '../../../db/entities/Poll.entity.js';
 import { PollStep } from '../../../db/entities/PollStep.entity.js';
@@ -131,7 +131,7 @@ export const pollCreate: ModalHandlerDelcaration<CTAData> = {
       return res.json({
         type: InteractionResponseType.ChannelMessageWithSource,
         data: {
-          flags: InteractionResponseFlags.EPHEMERAL,
+          flags: MessageFlags.Ephemeral,
           content: getSummary(aPoll),
           components: [
             {

--- a/src/commands/cta/poll/pollPub.ts
+++ b/src/commands/cta/poll/pollPub.ts
@@ -2,12 +2,9 @@ import {
   ButtonStyle,
   ComponentType,
   InteractionResponseType,
+  MessageFlags,
 } from 'discord-api-types/v10';
 import { CTAData, ModalHandlerDelcaration } from '../../modals.js';
-import {
-  InteractionResponseFlags,
-  MessageComponentTypes,
-} from 'discord-interactions';
 import { Poll } from '../../../db/entities/Poll.entity.js';
 import { logger } from '../../../logger.js';
 import { assertInteractionUserIsModerator } from '../../assert/assertInteractionUserIsModerator.js';
@@ -46,31 +43,31 @@ export const pollPub: ModalHandlerDelcaration<CTAData> = {
       return res.json({
         type: InteractionResponseType.ChannelMessageWithSource,
         data: {
-          flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+          flags: MessageFlags.IsComponentsV2,
           components: [
             {
-              type: MessageComponentTypes.SECTION,
+              type: ComponentType.Section,
               components: [
                 {
-                  type: MessageComponentTypes.TEXT_DISPLAY,
+                  type: ComponentType.TextDisplay,
                   content: t('poll.publish.header', {
                     mention: aPoll.role ? ` <@&${aPoll.role}>` : '',
                   }),
                 },
                 {
-                  type: MessageComponentTypes.TEXT_DISPLAY,
+                  type: ComponentType.TextDisplay,
                   content: aPoll.title,
                 },
               ],
               accessory: {
-                type: MessageComponentTypes.THUMBNAIL,
+                type: ComponentType.Thumbnail,
                 media: {
                   url: `https://raw.githubusercontent.com/GTSpray/P-titPote/main/assets/ptitpote-sam.png?salt=${pollId}`,
                 },
               },
             },
             {
-              type: MessageComponentTypes.SEPARATOR,
+              type: ComponentType.Separator,
               divider: true,
               spacing: 1,
             },

--- a/src/commands/modals.ts
+++ b/src/commands/modals.ts
@@ -1,4 +1,5 @@
-import { APIBaseInteraction, InteractionType } from 'discord.js';
+import type { APIBaseInteraction } from 'discord-api-types/v10';
+import { InteractionType } from 'discord-api-types/v10';
 import { Request, Response } from 'express';
 import { DBServices } from '../db/db.js';
 

--- a/src/commands/slash/alias/index.ts
+++ b/src/commands/slash/alias/index.ts
@@ -5,8 +5,8 @@ import {
   ApplicationIntegrationType,
   InteractionContextType,
   PermissionFlagsBits,
-  SlashCommandBuilder,
-} from 'discord.js';
+} from 'discord-api-types/v10';
+import { SlashCommandBuilder } from 'discord.js';
 
 import { aliasSetCommandData, set } from './set.js';
 import { aliasSayCommandData, say } from './say.js';

--- a/src/commands/slash/alias/ls.ts
+++ b/src/commands/slash/alias/ls.ts
@@ -1,10 +1,10 @@
 import { Response } from 'express';
 import { CommandHandlerOptions } from '../../commands.js';
 import {
-  InteractionResponseFlags,
+  ComponentType,
   InteractionResponseType,
-  MessageComponentTypes,
-} from 'discord-interactions';
+  MessageFlags,
+} from 'discord-api-types/v10';
 import { MessageAliased } from '../../../db/entities/MessageAliased.entity.js';
 import { foundItComponnents, notFoundPayload } from '../../commonMessages.js';
 
@@ -43,15 +43,15 @@ export const ls = async ({
       components = [
         ...foundItComponnents(),
         {
-          type: MessageComponentTypes.TEXT_DISPLAY,
+          type: ComponentType.TextDisplay,
           content: messageAliaseds.map((e) => `* ${e.alias}`).join('\n'),
         },
       ];
     }
     return res.json({
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      type: InteractionResponseType.ChannelMessageWithSource,
       data: {
-        flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+        flags: MessageFlags.IsComponentsV2,
         components,
       },
     });

--- a/src/commands/slash/alias/say.ts
+++ b/src/commands/slash/alias/say.ts
@@ -2,10 +2,10 @@ import * as z from 'zod';
 import { Response } from 'express';
 import { CommandHandlerOptions, SubCommandOption } from '../../commands.js';
 import {
-  InteractionResponseFlags,
+  ComponentType,
   InteractionResponseType,
-  MessageComponentTypes,
-} from 'discord-interactions';
+  MessageFlags,
+} from 'discord-api-types/v10';
 import { logger } from '../../../logger.js';
 import { MessageAliased } from '../../../db/entities/MessageAliased.entity.js';
 import { errorPayload } from '../../commonMessages.js';
@@ -61,12 +61,12 @@ export const say = async (
 
     if (messageAliased) {
       return res.json({
-        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        type: InteractionResponseType.ChannelMessageWithSource,
         data: {
-          flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+          flags: MessageFlags.IsComponentsV2,
           components: [
             {
-              type: MessageComponentTypes.TEXT_DISPLAY,
+              type: ComponentType.TextDisplay,
               content: messageAliased.message,
             },
           ],

--- a/src/commands/slash/alias/set.ts
+++ b/src/commands/slash/alias/set.ts
@@ -1,11 +1,7 @@
 import * as z from 'zod';
 import { Response } from 'express';
 import { CommandHandlerOptions, SubCommandOption } from '../../commands.js';
-import {
-  InteractionResponseFlags,
-  InteractionResponseType,
-  MessageComponentTypes,
-} from 'discord-interactions';
+import { InteractionResponseType, MessageFlags } from 'discord-api-types/v10';
 import { DiscordGuild } from '../../../db/entities/DiscordGuild.entity.js';
 import { MessageAliased } from '../../../db/entities/MessageAliased.entity.js';
 import { logger } from '../../../logger.js';
@@ -87,9 +83,9 @@ export const set = async (
 
     await em.persist(messageAliased).flush();
     return res.json({
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      type: InteractionResponseType.ChannelMessageWithSource,
       data: {
-        flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+        flags: MessageFlags.IsComponentsV2,
         components: [...okComponnents()],
       },
     });

--- a/src/commands/slash/gimme/emoji.ts
+++ b/src/commands/slash/gimme/emoji.ts
@@ -1,7 +1,7 @@
 import { CommandHandlerOptions } from '../../commands.js';
 import { Response } from 'express';
 import { logger } from '../../../logger.js';
-import { Routes, SlashCommandBuilder } from 'discord.js';
+import { SlashCommandBuilder } from 'discord.js';
 import {
   ApplicationIntegrationType,
   ComponentType,
@@ -10,6 +10,7 @@ import {
   MessageFlags,
   PermissionFlagsBits,
   RESTGetAPIChannelMessagesResult,
+  Routes,
 } from 'discord-api-types/v10';
 
 import { discordapi } from '../../../utils/discordapi.js';

--- a/src/commands/slash/gimme/emoji.ts
+++ b/src/commands/slash/gimme/emoji.ts
@@ -1,15 +1,13 @@
 import { CommandHandlerOptions } from '../../commands.js';
 import { Response } from 'express';
 import { logger } from '../../../logger.js';
-import {
-  InteractionResponseFlags,
-  InteractionResponseType,
-  MessageComponentTypes,
-} from 'discord-interactions';
 import { Routes, SlashCommandBuilder } from 'discord.js';
 import {
   ApplicationIntegrationType,
+  ComponentType,
   InteractionContextType,
+  InteractionResponseType,
+  MessageFlags,
   PermissionFlagsBits,
   RESTGetAPIChannelMessagesResult,
 } from 'discord-api-types/v10';
@@ -118,13 +116,13 @@ export const emoji = async ({
   logger.debug('extracted emojies', { reqId, emojies });
 
   return res.json({
-    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    type: InteractionResponseType.ChannelMessageWithSource,
     data: {
-      flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+      flags: MessageFlags.IsComponentsV2,
       components: [
         ...foundItComponnents(),
         {
-          type: MessageComponentTypes.MEDIA_GALLERY,
+          type: ComponentType.MediaGallery,
           items: emojies.map(({ url, name }) => ({
             description: name,
             media: { url },

--- a/src/commands/slash/gimme/index.ts
+++ b/src/commands/slash/gimme/index.ts
@@ -5,8 +5,8 @@ import {
   ApplicationIntegrationType,
   InteractionContextType,
   PermissionFlagsBits,
-  SlashCommandBuilder,
-} from 'discord.js';
+} from 'discord-api-types/v10';
+import { SlashCommandBuilder } from 'discord.js';
 
 import { Response } from 'express';
 import { logger } from '../../../logger.js';

--- a/src/commands/slash/gimme/otter.ts
+++ b/src/commands/slash/gimme/otter.ts
@@ -1,15 +1,13 @@
 import { CommandHandlerOptions } from '../../commands.js';
 import {
   ApplicationIntegrationType,
-  InteractionContextType,
-  PermissionFlagsBits,
-  SlashCommandBuilder,
-} from 'discord.js';
-import {
   ComponentType,
+  InteractionContextType,
   InteractionResponseType,
   MessageFlags,
+  PermissionFlagsBits,
 } from 'discord-api-types/v10';
+import { SlashCommandBuilder } from 'discord.js';
 
 import { Response } from 'express';
 import { foundItComponnents } from '../../commonMessages.js';

--- a/src/commands/slash/gimme/otter.ts
+++ b/src/commands/slash/gimme/otter.ts
@@ -1,9 +1,3 @@
-import {
-  InteractionResponseFlags,
-  InteractionResponseType,
-  MessageComponentTypes,
-} from 'discord-interactions';
-
 import { CommandHandlerOptions } from '../../commands.js';
 import {
   ApplicationIntegrationType,
@@ -11,6 +5,11 @@ import {
   PermissionFlagsBits,
   SlashCommandBuilder,
 } from 'discord.js';
+import {
+  ComponentType,
+  InteractionResponseType,
+  MessageFlags,
+} from 'discord-api-types/v10';
 
 import { Response } from 'express';
 import { foundItComponnents } from '../../commonMessages.js';
@@ -45,13 +44,13 @@ export const otter = async ({
   res,
 }: CommandHandlerOptions<gimmeOtterCommandData>): Promise<Response | null> => {
   return res.json({
-    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    type: InteractionResponseType.ChannelMessageWithSource,
     data: {
-      flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+      flags: MessageFlags.IsComponentsV2,
       components: [
         ...foundItComponnents(),
         {
-          type: MessageComponentTypes.MEDIA_GALLERY,
+          type: ComponentType.MediaGallery,
           items: [
             {
               description: 'otter',

--- a/src/commands/slash/gimme/version.ts
+++ b/src/commands/slash/gimme/version.ts
@@ -1,15 +1,13 @@
 import { CommandHandlerOptions } from '../../commands.js';
 import {
   ApplicationIntegrationType,
-  InteractionContextType,
-  PermissionFlagsBits,
-  SlashCommandBuilder,
-} from 'discord.js';
-import {
   ComponentType,
+  InteractionContextType,
   InteractionResponseType,
   MessageFlags,
+  PermissionFlagsBits,
 } from 'discord-api-types/v10';
+import { SlashCommandBuilder } from 'discord.js';
 
 import { getRandomEmoji } from '../../../utils/getRandomEmoji.js';
 

--- a/src/commands/slash/gimme/version.ts
+++ b/src/commands/slash/gimme/version.ts
@@ -1,9 +1,3 @@
-import {
-  InteractionResponseFlags,
-  InteractionResponseType,
-  MessageComponentTypes,
-} from 'discord-interactions';
-
 import { CommandHandlerOptions } from '../../commands.js';
 import {
   ApplicationIntegrationType,
@@ -11,6 +5,11 @@ import {
   PermissionFlagsBits,
   SlashCommandBuilder,
 } from 'discord.js';
+import {
+  ComponentType,
+  InteractionResponseType,
+  MessageFlags,
+} from 'discord-api-types/v10';
 
 import { getRandomEmoji } from '../../../utils/getRandomEmoji.js';
 
@@ -46,12 +45,12 @@ export const version = async ({
   res,
 }: CommandHandlerOptions<gimmeVersionCommandData>): Promise<Response | null> => {
   return res.json({
-    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    type: InteractionResponseType.ChannelMessageWithSource,
     data: {
-      flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+      flags: MessageFlags.IsComponentsV2,
       components: [
         {
-          type: MessageComponentTypes.TEXT_DISPLAY,
+          type: ComponentType.TextDisplay,
           content: t('gimme.version.message', {
             emoji: getRandomEmoji(),
             version: process.env.npm_package_version ?? 'unknown',

--- a/src/commands/slash/poll/index.ts
+++ b/src/commands/slash/poll/index.ts
@@ -5,8 +5,8 @@ import {
   ApplicationIntegrationType,
   InteractionContextType,
   PermissionFlagsBits,
-  SlashCommandBuilder,
-} from 'discord.js';
+} from 'discord-api-types/v10';
+import { SlashCommandBuilder } from 'discord.js';
 import { create, pollCreateCommandData } from './create.js';
 import { Response } from 'express';
 import { logger } from '../../../logger.js';

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -5,12 +5,12 @@ import {
   GatewayDispatchEvents,
   GatewayOpcodes,
   GatewayUpdatePresence,
+  InteractionType,
   PresenceUpdateStatus,
   Routes,
-} from 'discord.js';
+} from 'discord-api-types/v10';
 import { logger } from './logger.js';
 import { GWSEvent } from './gateway/gatewaytypes.js';
-import { InteractionType } from 'discord.js';
 import { discordapi } from './utils/discordapi.js';
 import { t } from './i18n/index.js';
 

--- a/src/gateway/GatewaySocket.ts
+++ b/src/gateway/GatewaySocket.ts
@@ -1,6 +1,7 @@
 import { ShardSocket } from './ShardSocket.js';
 import { discordapi } from '../utils/discordapi.js';
-import { type APIGatewayBotInfo, Routes } from 'discord.js';
+import type { APIGatewayBotInfo } from 'discord-api-types/v10';
+import { Routes } from 'discord-api-types/v10';
 import { logger } from '../logger.js';
 import { type GatewayEvent } from './gatewaytypes.js';
 import { TypedEventEmitter } from './TypedEventEmitter.js';

--- a/src/gateway/ShardSocket.ts
+++ b/src/gateway/ShardSocket.ts
@@ -7,7 +7,7 @@ import {
   GatewayIntentBits,
   GatewayInvalidSession,
   GatewayOpcodes,
-} from 'discord.js';
+} from 'discord-api-types/v10';
 import { WsClosedCode, GWSEvent } from './gatewaytypes.js';
 import { getPromiseWithTimeout } from '../utils/getPromiseWithTimeout.js';
 

--- a/src/gateway/gatewaytypes.ts
+++ b/src/gateway/gatewaytypes.ts
@@ -73,7 +73,7 @@ import {
   type GatewayVoiceServerUpdateDispatchData,
   type GatewayVoiceStateUpdateDispatchData,
   type GatewayWebhooksUpdateDispatchData,
-} from 'discord.js';
+} from 'discord-api-types/v10';
 
 export enum GWSEvent {
   Debug = 'DEBUG',

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { Routes } from 'discord.js';
+import { Routes } from 'discord-api-types/v10';
 import { discordapi } from './utils/discordapi.js';
 import { slashcommandsRegister } from './commands/slash/index.js';
 import { logger } from './logger.js';

--- a/tests/mocks/discord-api/getAPIInteractionGuildMemberData.ts
+++ b/tests/mocks/discord-api/getAPIInteractionGuildMemberData.ts
@@ -1,4 +1,5 @@
-import { APIInteractionGuildMember, GuildMemberFlags } from 'discord.js';
+import type { APIInteractionGuildMember } from 'discord-api-types/v10';
+import { GuildMemberFlags } from 'discord-api-types/v10';
 import { randomDiscordId16 } from './utils.js';
 import { getApiUserData } from './getApiUserData.js';
 

--- a/tests/mocks/discord-api/getApiChannelData.ts
+++ b/tests/mocks/discord-api/getApiChannelData.ts
@@ -1,4 +1,5 @@
-import { APIChannel, ChannelType } from 'discord.js';
+import type { APIChannel } from 'discord-api-types/v10';
+import { ChannelType } from 'discord-api-types/v10';
 import { BitFieldFlag, getRandomString, randomDiscordId19 } from './utils.js';
 
 export const getApiChannelData = (

--- a/tests/mocks/discord-api/getApiMessageChannelData.ts
+++ b/tests/mocks/discord-api/getApiMessageChannelData.ts
@@ -1,6 +1,6 @@
-import { RESTGetAPIChannelMessagesResult } from 'discord.js';
+import type { RESTGetAPIChannelMessagesResult } from 'discord-api-types/v10';
 import { getApiMessageData } from './getApiMessageData.js';
-import { randomDiscordId19 } from './utils';
+import { randomDiscordId19 } from './utils.js';
 
 type ApiMessagesChannelDataOptions = {
   channel_id?: string;

--- a/tests/mocks/discord-api/getApiMessageData.ts
+++ b/tests/mocks/discord-api/getApiMessageData.ts
@@ -1,4 +1,5 @@
-import { APIMessage, MessageType } from 'discord.js';
+import type { APIMessage } from 'discord-api-types/v10';
+import { MessageType } from 'discord-api-types/v10';
 import { BitFieldFlag, getRandomString, randomDiscordId19 } from './utils.js';
 import { getApiUserData } from './getApiUserData.js';
 

--- a/tests/mocks/discord-api/getApiUserData.ts
+++ b/tests/mocks/discord-api/getApiUserData.ts
@@ -1,4 +1,5 @@
-import { APIUser, UserFlags } from 'discord.js';
+import type { APIUser } from 'discord-api-types/v10';
+import { UserFlags } from 'discord-api-types/v10';
 import { getRandomString, randomDiscordId18 } from './utils.js';
 
 export const getApiUserData = (options: Partial<APIUser> = {}): APIUser => {

--- a/tests/mocks/discordGatewayMsg.ts
+++ b/tests/mocks/discordGatewayMsg.ts
@@ -7,7 +7,7 @@ import {
   GatewayReadyDispatch,
   GatewayReconnect,
   GatewayResumedDispatch,
-} from 'discord.js';
+} from 'discord-api-types/v10';
 import { getRandomString, randomDiscordId19 } from './discord-api/utils.js';
 
 export const helloMsg = (d: { heartbeat_interval?: number }): GatewayHello => ({

--- a/tests/mocks/discordjs.ts
+++ b/tests/mocks/discordjs.ts
@@ -1,4 +1,8 @@
-import { RequestData, RouteLike } from 'discord.js';
+type RouteLike = `/${string}`;
+type RequestData = {
+  body?: unknown;
+  query?: URLSearchParams;
+};
 
 export enum DiscrodRESTMockVerb {
   get = 'get',

--- a/tests/mocks/getInteractionHttpMock.ts
+++ b/tests/mocks/getInteractionHttpMock.ts
@@ -12,7 +12,8 @@ import {
 
 import { Request, Response } from 'express';
 
-import { APIBaseInteraction, InteractionType, Locale } from 'discord.js';
+import type { APIBaseInteraction } from 'discord-api-types/v10';
+import { InteractionType, Locale } from 'discord-api-types/v10';
 import { getAPIInteractionGuildMemberData } from './discord-api/getAPIInteractionGuildMemberData.js';
 import { getApiUserData } from './discord-api/getApiUserData.js';
 import { getApiChannelData } from './discord-api/getApiChannelData.js';

--- a/tests/src/commands/slashs/alias/alias.spec.ts
+++ b/tests/src/commands/slashs/alias/alias.spec.ts
@@ -19,10 +19,7 @@ import {
   PermissionFlagsBits,
 } from 'discord.js';
 
-import {
-  InteractionResponseFlags,
-  InteractionResponseType,
-} from 'discord-interactions';
+import { InteractionResponseType, MessageFlags } from 'discord-api-types/v10';
 import {
   admin_permissions,
   default_member_permissions,
@@ -127,9 +124,9 @@ describe('/alias', () => {
       const response = await alias.handler(fakeOpts);
 
       expect(response).toMeetApiResponse(200, {
-        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        type: InteractionResponseType.ChannelMessageWithSource,
         data: {
-          flags: InteractionResponseFlags.EPHEMERAL,
+          flags: MessageFlags.Ephemeral,
           content: t('common.notAllowed'),
         },
       });
@@ -231,9 +228,9 @@ describe('/alias', () => {
       const response = await alias.handler(fakeOpts);
 
       expect(response).toMeetApiResponse(200, {
-        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        type: InteractionResponseType.ChannelMessageWithSource,
         data: {
-          flags: InteractionResponseFlags.EPHEMERAL,
+          flags: MessageFlags.Ephemeral,
           content: t('common.notAllowed'),
         },
       });
@@ -324,9 +321,9 @@ describe('/alias', () => {
       const response = await alias.handler(fakeOpts);
 
       expect(response).toMeetApiResponse(200, {
-        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        type: InteractionResponseType.ChannelMessageWithSource,
         data: {
-          flags: InteractionResponseFlags.EPHEMERAL,
+          flags: MessageFlags.Ephemeral,
           content: t('common.notAllowed'),
         },
       });

--- a/tests/src/commands/slashs/alias/alias.spec.ts
+++ b/tests/src/commands/slashs/alias/alias.spec.ts
@@ -14,12 +14,12 @@ import { type aliasSetSubCommandData } from '../../../../../src/commands/slash/a
 import { type aliasSaySubCommandData } from '../../../../../src/commands/slash/alias/say.js';
 import { type aliasLsSubCommandData } from '../../../../../src/commands/slash/alias/ls.js';
 import {
-  InteractionContextType,
   ApplicationIntegrationType,
+  InteractionContextType,
+  InteractionResponseType,
+  MessageFlags,
   PermissionFlagsBits,
-} from 'discord.js';
-
-import { InteractionResponseType, MessageFlags } from 'discord-api-types/v10';
+} from 'discord-api-types/v10';
 import {
   admin_permissions,
   default_member_permissions,

--- a/tests/src/commands/slashs/alias/ls.spec.ts
+++ b/tests/src/commands/slashs/alias/ls.spec.ts
@@ -4,10 +4,10 @@ import {
   ls,
 } from '../../../../../src/commands/slash/alias/ls.js';
 import {
-  InteractionResponseFlags,
+  ComponentType,
   InteractionResponseType,
-  MessageComponentTypes,
-} from 'discord-interactions';
+  MessageFlags,
+} from 'discord-api-types/v10';
 import { getInteractionCommandHttpMock } from '../../../../mocks/getInteractionHttpMock.js';
 import { randomDiscordId19 } from '../../../../mocks/discord-api/utils.js';
 import { CommandHandlerOptions } from '../../../../../src/commands/commands.js';
@@ -31,9 +31,9 @@ describe('/alias ls', () => {
   >;
 
   const notFoundMessagePayload = {
-    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    type: InteractionResponseType.ChannelMessageWithSource,
     data: {
-      flags: InteractionResponseFlags.EPHEMERAL,
+      flags: MessageFlags.Ephemeral,
       content: t('common.notFound'),
     },
   };
@@ -94,21 +94,21 @@ describe('/alias ls', () => {
       const response = await ls(handlerOpts);
 
       expect(response).toMeetApiResponse(200, {
-        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        type: InteractionResponseType.ChannelMessageWithSource,
         data: {
-          flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+          flags: MessageFlags.IsComponentsV2,
           components: [
             {
-              type: MessageComponentTypes.TEXT_DISPLAY,
+              type: ComponentType.TextDisplay,
               content: t('common.foundIt'),
             },
             {
-              type: MessageComponentTypes.SEPARATOR,
+              type: ComponentType.Separator,
               divider: true,
               spacing: 1,
             },
             {
-              type: MessageComponentTypes.TEXT_DISPLAY,
+              type: ComponentType.TextDisplay,
               content: messageAliaseds.map((e) => `* ${e.alias}`).join('\n'),
             },
           ],
@@ -125,21 +125,21 @@ describe('/alias ls', () => {
       const response = await ls(handlerOpts);
 
       expect(response).toMeetApiResponse(200, {
-        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        type: InteractionResponseType.ChannelMessageWithSource,
         data: {
-          flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+          flags: MessageFlags.IsComponentsV2,
           components: [
             {
-              type: MessageComponentTypes.TEXT_DISPLAY,
+              type: ComponentType.TextDisplay,
               content: t('common.foundIt'),
             },
             {
-              type: MessageComponentTypes.SEPARATOR,
+              type: ComponentType.Separator,
               divider: true,
               spacing: 1,
             },
             {
-              type: MessageComponentTypes.TEXT_DISPLAY,
+              type: ComponentType.TextDisplay,
               content: expect.not.stringContaining(softDeleted.alias),
             },
           ],
@@ -173,21 +173,21 @@ describe('/alias ls', () => {
       const response = await ls(handlerOpts);
 
       expect(response).toMeetApiResponse(200, {
-        type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+        type: InteractionResponseType.ChannelMessageWithSource,
         data: {
-          flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+          flags: MessageFlags.IsComponentsV2,
           components: [
             {
-              type: MessageComponentTypes.TEXT_DISPLAY,
+              type: ComponentType.TextDisplay,
               content: t('common.foundIt'),
             },
             {
-              type: MessageComponentTypes.SEPARATOR,
+              type: ComponentType.Separator,
               divider: true,
               spacing: 1,
             },
             {
-              type: MessageComponentTypes.TEXT_DISPLAY,
+              type: ComponentType.TextDisplay,
               content: expect.not.stringContaining(otherAlias.alias),
             },
           ],

--- a/tests/src/commands/slashs/alias/say.spec.ts
+++ b/tests/src/commands/slashs/alias/say.spec.ts
@@ -4,10 +4,10 @@ import {
   say,
 } from '../../../../../src/commands/slash/alias/say.js';
 import {
-  InteractionResponseFlags,
+  ComponentType,
   InteractionResponseType,
-  MessageComponentTypes,
-} from 'discord-interactions';
+  MessageFlags,
+} from 'discord-api-types/v10';
 import { getInteractionCommandHttpMock } from '../../../../mocks/getInteractionHttpMock.js';
 import {
   getRandomString,
@@ -81,12 +81,12 @@ describe('/alias say', () => {
     const response = await say(handlerOpts, subcommand);
 
     expect(response).toMeetApiResponse(200, {
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      type: InteractionResponseType.ChannelMessageWithSource,
       data: {
-        flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+        flags: MessageFlags.IsComponentsV2,
         components: [
           {
-            type: MessageComponentTypes.TEXT_DISPLAY,
+            type: ComponentType.TextDisplay,
             content: messageAliased.message,
           },
         ],
@@ -107,9 +107,9 @@ describe('/alias say', () => {
     const response = await say({ ...handlerOpts, req, res }, subcommand);
 
     expect(response).toMeetApiResponse(200, {
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      type: InteractionResponseType.ChannelMessageWithSource,
       data: {
-        flags: InteractionResponseFlags.EPHEMERAL,
+        flags: MessageFlags.Ephemeral,
         content: t('alias.say.notFound', {
           alias: aliasOpts.value,
         }),

--- a/tests/src/commands/slashs/alias/set.spec.ts
+++ b/tests/src/commands/slashs/alias/set.spec.ts
@@ -3,10 +3,10 @@ import {
   set,
 } from '../../../../../src/commands/slash/alias/set.js';
 import {
-  InteractionResponseFlags,
+  ComponentType,
   InteractionResponseType,
-  MessageComponentTypes,
-} from 'discord-interactions';
+  MessageFlags,
+} from 'discord-api-types/v10';
 import { getInteractionCommandHttpMock } from '../../../../mocks/getInteractionHttpMock.js';
 import {
   getRandomString,
@@ -79,12 +79,12 @@ describe('/alias set', () => {
     const response = await set(handlerOpts, subcommand);
 
     expect(response).toMeetApiResponse(200, {
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      type: InteractionResponseType.ChannelMessageWithSource,
       data: {
-        flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+        flags: MessageFlags.IsComponentsV2,
         components: [
           {
-            type: MessageComponentTypes.TEXT_DISPLAY,
+            type: ComponentType.TextDisplay,
             content: t('common.ok'),
           },
         ],

--- a/tests/src/commands/slashs/gimme/emoji.spec.ts
+++ b/tests/src/commands/slashs/gimme/emoji.spec.ts
@@ -1,10 +1,10 @@
 import { Request } from 'express';
 import { MockRequest } from 'node-mocks-http';
 import {
-  InteractionResponseFlags,
+  ComponentType,
   InteractionResponseType,
-  MessageComponentTypes,
-} from 'discord-interactions';
+  MessageFlags,
+} from 'discord-api-types/v10';
 import { getInteractionCommandHttpMock } from '../../../../mocks/getInteractionHttpMock.js';
 import { REST, Routes } from 'discord.js';
 import {
@@ -43,9 +43,9 @@ describe('/gimme emoji', () => {
     type: 1,
   };
   const notFoundMessagePayload = {
-    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    type: InteractionResponseType.ChannelMessageWithSource,
     data: {
-      flags: InteractionResponseFlags.EPHEMERAL,
+      flags: MessageFlags.Ephemeral,
       content: t('common.notFound'),
     },
   };
@@ -161,21 +161,21 @@ describe('/gimme emoji', () => {
 
         const response = await emoji(handlerOpts);
         expect(response).toMeetApiResponse(200, {
-          type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+          type: InteractionResponseType.ChannelMessageWithSource,
           data: {
-            flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+            flags: MessageFlags.IsComponentsV2,
             components: [
               {
-                type: MessageComponentTypes.TEXT_DISPLAY,
+                type: ComponentType.TextDisplay,
                 content: t('common.foundIt'),
               },
               {
-                type: MessageComponentTypes.SEPARATOR,
+                type: ComponentType.Separator,
                 divider: true,
                 spacing: 1,
               },
               {
-                type: MessageComponentTypes.MEDIA_GALLERY,
+                type: ComponentType.MediaGallery,
                 items: [
                   {
                     description: emojiName,
@@ -211,21 +211,21 @@ describe('/gimme emoji', () => {
 
     const response = await emoji(handlerOpts);
     expect(response).toMeetApiResponse(200, {
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      type: InteractionResponseType.ChannelMessageWithSource,
       data: {
-        flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+        flags: MessageFlags.IsComponentsV2,
         components: [
           {
-            type: MessageComponentTypes.TEXT_DISPLAY,
+            type: ComponentType.TextDisplay,
             content: expect.any(String),
           },
           {
-            type: MessageComponentTypes.SEPARATOR,
+            type: ComponentType.Separator,
             divider: true,
             spacing: 1,
           },
           {
-            type: MessageComponentTypes.MEDIA_GALLERY,
+            type: ComponentType.MediaGallery,
             items: expect.toBeArrayOfSize(stealemoji_emojiLimit),
           },
         ],
@@ -258,21 +258,21 @@ describe('/gimme emoji', () => {
 
     const response = await emoji(handlerOpts);
     expect(response).toMeetApiResponse(200, {
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      type: InteractionResponseType.ChannelMessageWithSource,
       data: {
-        flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+        flags: MessageFlags.IsComponentsV2,
         components: [
           {
-            type: MessageComponentTypes.TEXT_DISPLAY,
+            type: ComponentType.TextDisplay,
             content: expect.any(String),
           },
           {
-            type: MessageComponentTypes.SEPARATOR,
+            type: ComponentType.Separator,
             divider: true,
             spacing: 1,
           },
           {
-            type: MessageComponentTypes.MEDIA_GALLERY,
+            type: ComponentType.MediaGallery,
             items: expect.toBeArrayOfSize(1),
           },
         ],

--- a/tests/src/commands/slashs/gimme/emoji.spec.ts
+++ b/tests/src/commands/slashs/gimme/emoji.spec.ts
@@ -6,7 +6,8 @@ import {
   MessageFlags,
 } from 'discord-api-types/v10';
 import { getInteractionCommandHttpMock } from '../../../../mocks/getInteractionHttpMock.js';
-import { REST, Routes } from 'discord.js';
+import { REST } from 'discord.js';
+import { Routes } from 'discord-api-types/v10';
 import {
   getRandomString,
   randomDiscordId19,

--- a/tests/src/commands/slashs/gimme/gimme.spec.ts
+++ b/tests/src/commands/slashs/gimme/gimme.spec.ts
@@ -11,10 +11,10 @@ import * as versionModule from '../../../../../src/commands/slash/gimme/version.
 import { DBServices } from '../../../../../src/db/db.js';
 import { initORM } from '../../../../initORM.js';
 import {
-  InteractionContextType,
   ApplicationIntegrationType,
+  InteractionContextType,
   PermissionFlagsBits,
-} from 'discord.js';
+} from 'discord-api-types/v10';
 import { t } from '../../../../../src/i18n/index.js';
 
 describe('/gimme', () => {

--- a/tests/src/commands/slashs/gimme/otter.spec.ts
+++ b/tests/src/commands/slashs/gimme/otter.spec.ts
@@ -1,8 +1,8 @@
 import {
-  InteractionResponseFlags,
+  ComponentType,
   InteractionResponseType,
-  MessageComponentTypes,
-} from 'discord-interactions';
+  MessageFlags,
+} from 'discord-api-types/v10';
 import { getInteractionCommandHttpMock } from '../../../../mocks/getInteractionHttpMock.js';
 import { randomDiscordId19 } from '../../../../mocks/discord-api/utils.js';
 import { CommandHandlerOptions } from '../../../../../src/commands/commands.js';
@@ -41,21 +41,21 @@ describe('/gimme otter', () => {
     const response = await otter(handlerOpts);
 
     expect(response).toMeetApiResponse(200, {
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      type: InteractionResponseType.ChannelMessageWithSource,
       data: {
-        flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+        flags: MessageFlags.IsComponentsV2,
         components: [
           {
-            type: MessageComponentTypes.TEXT_DISPLAY,
+            type: ComponentType.TextDisplay,
             content: t('common.foundIt'),
           },
           {
-            type: MessageComponentTypes.SEPARATOR,
+            type: ComponentType.Separator,
             divider: true,
             spacing: 1,
           },
           {
-            type: MessageComponentTypes.MEDIA_GALLERY,
+            type: ComponentType.MediaGallery,
             items: [
               {
                 description: 'otter',

--- a/tests/src/commands/slashs/gimme/version.spec.ts
+++ b/tests/src/commands/slashs/gimme/version.spec.ts
@@ -1,8 +1,8 @@
 import {
-  InteractionResponseFlags,
+  ComponentType,
   InteractionResponseType,
-  MessageComponentTypes,
-} from 'discord-interactions';
+  MessageFlags,
+} from 'discord-api-types/v10';
 import { getInteractionCommandHttpMock } from '../../../../mocks/getInteractionHttpMock.js';
 import { randomDiscordId19 } from '../../../../mocks/discord-api/utils.js';
 import { CommandHandlerOptions } from '../../../../../src/commands/commands.js';
@@ -46,12 +46,12 @@ describe('/gimme version', () => {
     const response = await version(handlerOpts);
 
     expect(response).toMeetApiResponse(200, {
-      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      type: InteractionResponseType.ChannelMessageWithSource,
       data: {
-        flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+        flags: MessageFlags.IsComponentsV2,
         components: [
           {
-            type: MessageComponentTypes.TEXT_DISPLAY,
+            type: ComponentType.TextDisplay,
             content: t('gimme.version.message', {
               emoji: anEmote,
               version: `${process.env.npm_package_version}`,

--- a/tests/src/commands/slashs/poll/poll.spec.ts
+++ b/tests/src/commands/slashs/poll/poll.spec.ts
@@ -8,10 +8,10 @@ import { randomDiscordId19 } from '../../../../mocks/discord-api/utils.js';
 import { CommandHandlerOptions } from '../../../../../src/commands/commands.js';
 import { initORM } from '../../../../initORM.js';
 import {
-  InteractionContextType,
   ApplicationIntegrationType,
+  InteractionContextType,
   PermissionFlagsBits,
-} from 'discord.js';
+} from 'discord-api-types/v10';
 import { pollCreateSubCommandData } from '../../../../../src/commands/slash/poll/create.js';
 import { t } from '../../../../../src/i18n/index.js';
 

--- a/tests/src/cta/poll/pollAddC.spec.ts
+++ b/tests/src/cta/poll/pollAddC.spec.ts
@@ -2,8 +2,7 @@ import {
   SqlEntityManager,
   AbstractSqlDriver,
   AbstractSqlConnection,
-  AbstractSqlPlatform,
-  applyPopulateHints,
+  AbstractSqlPlatform
 } from '@mikro-orm/mariadb';
 import {
   pollAddC,

--- a/tests/src/cta/poll/pollAddC.spec.ts
+++ b/tests/src/cta/poll/pollAddC.spec.ts
@@ -2,7 +2,7 @@ import {
   SqlEntityManager,
   AbstractSqlDriver,
   AbstractSqlConnection,
-  AbstractSqlPlatform
+  AbstractSqlPlatform,
 } from '@mikro-orm/mariadb';
 import {
   pollAddC,

--- a/tests/src/cta/poll/pollCreate.spec.ts
+++ b/tests/src/cta/poll/pollCreate.spec.ts
@@ -20,7 +20,6 @@ import {
   InteractionResponseType,
   MessageFlags,
 } from 'discord-api-types/v10';
-import { InteractionResponseFlags } from 'discord-interactions';
 import { expectedPoll } from '../../../epectedEntities/expectedPoll.js';
 import { Poll } from '../../../../src/db/entities/Poll.entity.js';
 import {
@@ -209,7 +208,7 @@ describe('cta/pollCreate', () => {
       expect(response).toMeetApiResponse(200, {
         type: InteractionResponseType.ChannelMessageWithSource,
         data: {
-          flags: InteractionResponseFlags.EPHEMERAL,
+          flags: MessageFlags.Ephemeral,
           content: expect.any(String),
           components: expect.any(Array),
         },
@@ -391,7 +390,7 @@ describe('cta/pollCreate', () => {
       expect(response).toMeetApiResponse(200, {
         type: InteractionResponseType.ChannelMessageWithSource,
         data: {
-          flags: InteractionResponseFlags.EPHEMERAL,
+          flags: MessageFlags.Ephemeral,
           content: expect.any(String),
           components: expect.any(Array),
         },
@@ -570,7 +569,7 @@ describe('cta/pollCreate', () => {
       expect(response).toMeetApiResponse(200, {
         type: InteractionResponseType.ChannelMessageWithSource,
         data: {
-          flags: InteractionResponseFlags.EPHEMERAL,
+          flags: MessageFlags.Ephemeral,
           content: expect.any(String),
           components: expect.any(Array),
         },

--- a/tests/src/cta/poll/pollPub.spec.ts
+++ b/tests/src/cta/poll/pollPub.spec.ts
@@ -22,10 +22,6 @@ import {
 import { Poll } from '../../../../src/db/entities/Poll.entity.js';
 import { PollStep } from '../../../../src/db/entities/PollStep.entity.js';
 import {
-  InteractionResponseFlags,
-  MessageComponentTypes,
-} from 'discord-interactions';
-import {
   admin_permissions,
   default_member_permissions,
 } from '../../../mocks/discord-api/rolePermission.js';
@@ -98,29 +94,29 @@ describe('cta/pollPub', () => {
     expect(response).toMeetApiResponse(200, {
       type: InteractionResponseType.ChannelMessageWithSource,
       data: {
-        flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+        flags: MessageFlags.IsComponentsV2,
         components: [
           {
-            type: MessageComponentTypes.SECTION,
+            type: ComponentType.Section,
             components: [
               {
-                type: MessageComponentTypes.TEXT_DISPLAY,
+                type: ComponentType.TextDisplay,
                 content: t('poll.publish.header', { mention: '' }),
               },
               {
-                type: MessageComponentTypes.TEXT_DISPLAY,
+                type: ComponentType.TextDisplay,
                 content: aPoll.title,
               },
             ],
             accessory: {
-              type: MessageComponentTypes.THUMBNAIL,
+              type: ComponentType.Thumbnail,
               media: {
                 url: `https://raw.githubusercontent.com/GTSpray/P-titPote/main/assets/ptitpote-sam.png?salt=${aPoll.id}`,
               },
             },
           },
           {
-            type: MessageComponentTypes.SEPARATOR,
+            type: ComponentType.Separator,
             divider: true,
             spacing: 1,
           },
@@ -155,31 +151,31 @@ describe('cta/pollPub', () => {
     expect(response).toMeetApiResponse(200, {
       type: InteractionResponseType.ChannelMessageWithSource,
       data: {
-        flags: InteractionResponseFlags.IS_COMPONENTS_V2,
+        flags: MessageFlags.IsComponentsV2,
         components: [
           {
-            type: MessageComponentTypes.SECTION,
+            type: ComponentType.Section,
             components: [
               {
-                type: MessageComponentTypes.TEXT_DISPLAY,
+                type: ComponentType.TextDisplay,
                 content: t('poll.publish.header', {
                   mention: ` <@&${aPoll.role}>`,
                 }),
               },
               {
-                type: MessageComponentTypes.TEXT_DISPLAY,
+                type: ComponentType.TextDisplay,
                 content: aPoll.title,
               },
             ],
             accessory: {
-              type: MessageComponentTypes.THUMBNAIL,
+              type: ComponentType.Thumbnail,
               media: {
                 url: `https://raw.githubusercontent.com/GTSpray/P-titPote/main/assets/ptitpote-sam.png?salt=${aPoll.id}`,
               },
             },
           },
           {
-            type: MessageComponentTypes.SEPARATOR,
+            type: ComponentType.Separator,
             divider: true,
             spacing: 1,
           },

--- a/tests/src/gateway/GatewaySocket.spec.ts
+++ b/tests/src/gateway/GatewaySocket.spec.ts
@@ -1,4 +1,5 @@
-import { REST, Routes } from 'discord.js';
+import { REST } from 'discord.js';
+import { Routes } from 'discord-api-types/v10';
 import { GatewaySocket } from '../../../src/gateway/GatewaySocket.js';
 import { DiscrodRESTMock, DiscrodRESTMockVerb } from '../../mocks/discordjs.js';
 import { ShardSocket } from '../../../src/gateway/ShardSocket.js';

--- a/tests/src/gateway/ShardSocket.spec.ts
+++ b/tests/src/gateway/ShardSocket.spec.ts
@@ -13,7 +13,7 @@ import {
   GatewayIntentBits,
   GatewayOpcodes,
   GatewayReadyDispatch,
-} from 'discord.js';
+} from 'discord-api-types/v10';
 import { WebSocketServerMock } from '../../mocks/WebSocketMock.js';
 import { WsClosedCode, GWSEvent } from '../../../src/gateway/gatewaytypes.js';
 

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "rootDir": ".."
   },
-  "include": ["./**/*"]
+  "include": ["./**/*", "../global.d.ts"],
+  "files": []
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "nodenext",
     "target": "ES2022",
     "outDir": "dist",
+    "rootDir": ".",
     "noEmitOnError": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Replace discord-interactions and discord.js type imports with
discord-api-types/v10 for interactions, gateway payloads, REST routes