### PR TITLE
feat(docker): publish per-arch GHCR tags on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Get version after release
         id: after
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Set up QEMU
+        if: steps.before.outputs.version != steps.after.outputs.version
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        if: steps.before.outputs.version != steps.after.outputs.version
+        uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
         if: steps.before.outputs.version != steps.after.outputs.version
         uses: docker/login-action@v3
@@ -39,12 +45,23 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish Docker image
+      - name: Publish Docker image (linux/amd64)
         if: steps.before.outputs.version != steps.after.outputs.version
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/ptitpote/Dockerfile
           target: ptitpote
+          platforms: linux/amd64
           push: true
-          tags: ghcr.io/gtspray/ptitpote:${{ steps.after.outputs.version }}
+          tags: ghcr.io/gtspray/ptitpote:${{ steps.after.outputs.version }}-amd64
+      - name: Publish Docker image (linux/arm64)
+        if: steps.before.outputs.version != steps.after.outputs.version
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/ptitpote/Dockerfile
+          target: ptitpote
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/gtspray/ptitpote:${{ steps.after.outputs.version }}-arm64


### PR DESCRIPTION
Build and push separate amd64 and arm64 images so hosts can pull an architecture-specific tag without relying on a multi-arch manifest.